### PR TITLE
Fix: Resolve web.php conflicts and correct auth implementation

### DIFF
--- a/app/Http/Controllers/Auth/CustomForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/CustomForgotPasswordController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\RedirectResponse;
 // use Illuminate\Support\Facades\Password; // Not using Laravel's default broker directly here
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Mail; // Import Mail facade
+use Illuminate\Support\Facades\Log; // Import Log facade
 use App\Mail\CustomPasswordResetLinkMail; // Import Mailable
 
 
@@ -75,7 +76,7 @@ class CustomForgotPasswordController extends Controller
         } catch (\Exception $e) {
             // Log the error or handle it gracefully if mail sending fails
             // For now, we'll proceed, but in production, you might want to inform the user or retry
-            // Log::error('Failed to send password reset email: ' . $e->getMessage());
+            Log::error('Failed to send password reset email: ' . $e->getMessage());
             // If mail is critical, you might even rollback the token storage or queue the email.
             // For this exercise, we'll assume it's okay to show success even if mail fails silently here,
             // or rely on global exception handling. A better approach would be to queue emails.

--- a/app/Http/Controllers/Auth/CustomRegisterController.php
+++ b/app/Http/Controllers/Auth/CustomRegisterController.php
@@ -51,7 +51,7 @@ class CustomRegisterController extends Controller
             'email' => $request->email,
             'password' => Hash::make($request->password),
             'role_id' => $clientRole ? $clientRole->id : null, // Assign role_id if Client role found
-            'created_by' => 1, // As per requirement, set created_by to 1 (presumably an admin or system user ID)
+            'created_by' => null, // For self-registration, created_by is null
             // 'email_verified_at' => now(), // Optionally, verify email straight away
         ]);
 

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Http\Request;
+
+class Authenticate extends Middleware
+{
+    /**
+     * Get the path the user should be redirected to when they are not authenticated.
+     */
+    protected function redirectTo(Request $request): ?string
+    {
+        return $request->expectsJson() ? null : route('custom.login');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,16 +27,6 @@ use Illuminate\Support\Facades\Route;
 
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-Route::get('/home', function () {
-    return view('home');
-})->name('home');
-
-=======
->>>>>>> 3f425e2c5bf71e7195350fb49e7ac12032322d78
-=======
->>>>>>> 3f425e2c5bf71e7195350fb49e7ac12032322d78
 Route::get('/products', [ArticleController::class, 'productList'])->name('products.index');
 
 Route::get('/products/{id}', [ArticleController::class, 'productShow'])->name('products.show');
@@ -88,7 +78,6 @@ Route::resource('permissions', PermissionController::class);
 Route::resource('categories', CategorieController::class);
 Route::resource('fournisseurs', FournisseurController::class);
 Route::resource('emplacements',EmplacementController::class);
-Route::resource('articles', ArticleController::class);
 Route::resource('factures', FactureController::class);
 Route::resource('accueil', AccueilController::class); // This likely creates a GET '/' route already if 'index' is typical resource method
 // Ensure the primary GET / route is explicitly named 'home' and points to AccueilController@index


### PR DESCRIPTION
This commit addresses several issues related to routing and user authentication:

- Resolves merge conflicts within `routes/web.php` and removes a redundant `/home` route definition.
- Recreates the missing `app/Http/Middleware/Authenticate.php` middleware to ensure proper protection of authenticated routes, redirecting to your custom login page.
- Refines `routes/web.php` by removing a duplicate `ArticleController` resource route definition.
- Corrects the `CustomRegisterController` to set `created_by` to `null` for self-registered users, aligning with the nullable database schema.
- Improves error handling in `CustomForgotPasswordController` by uncommenting the error log statement for email sending failures and adding the required `Log` facade import.

These changes aim to stabilize the routing system and ensure the custom authentication flow functions as intended.