### PR TITLE
Fix: Correct admin article route names in views

### DIFF
--- a/resources/views/articles/create.blade.php
+++ b/resources/views/articles/create.blade.php
@@ -8,7 +8,7 @@
     <ul class="breadcrumbs">
         <li class="nav-home"><a href="#"><i class="icon-home"></i></a></li>
         <li class="separator"><i class="icon-arrow-right"></i></li>
-        <li class="nav-item"><a href="{{ route('articles.index') }}">Articles</a></li>
+        <li class="nav-item"><a href="{{ route('admin.articles.index') }}">Articles</a></li>
         <li class="separator"><i class="icon-arrow-right"></i></li>
         <li class="nav-item">Ajouter</li>
     </ul>
@@ -31,7 +31,7 @@
                     </div>
                 @endif
 
-                <form action="{{ route('articles.store') }}" method="POST" enctype="multipart/form-data">
+                <form action="{{ route('admin.articles.store') }}" method="POST" enctype="multipart/form-data">
                     @csrf
                     <div class="form-group">
                         <label for="name">Nom de l'article</label>
@@ -103,7 +103,7 @@
 
                     <div class="card-action">
                         <button type="submit" class="btn btn-success">Enregistrer</button>
-                        <a href="{{ route('articles.index') }}" class="btn btn-danger">Annuler</a>
+                        <a href="{{ route('admin.articles.index') }}" class="btn btn-danger">Annuler</a>
                     </div>
                 </form>
             </div>

--- a/resources/views/articles/edit.blade.php
+++ b/resources/views/articles/edit.blade.php
@@ -6,9 +6,9 @@
 <div class="page-header">
     <h3 class="fw-bold mb-3">Modifier l'Article</h3>
     <ul class="breadcrumbs">
-        <li class="nav-home"><a href="{{ route('welcome') }}"><i class="icon-home"></i></a></li>
+        <li class="nav-home"><a href="{{ route('admin.articles.index') }}"><i class="icon-home"></i></a></li>
         <li class="separator"><i class="icon-arrow-right"></i></li>
-        <li class="nav-item"><a href="{{ route('articles.index') }}">Articles</a></li>
+        <li class="nav-item"><a href="{{ route('admin.articles.index') }}">Articles</a></li>
         <li class="separator"><i class="icon-arrow-right"></i></li>
         <li class="nav-item">Modifier : {{ $article->name }}</li>
     </ul>
@@ -31,7 +31,7 @@
                     </div>
                 @endif
 
-                <form action="{{ route('articles.update', $article->id) }}" method="POST" enctype="multipart/form-data">
+                <form action="{{ route('admin.articles.update', $article->id) }}" method="POST" enctype="multipart/form-data">
                     @csrf
                     @method('PUT')
                     <div class="form-group">
@@ -108,7 +108,7 @@
 
                     <div class="card-action">
                         <button type="submit" class="btn btn-success">Enregistrer les modifications</button>
-                        <a href="{{ route('articles.index') }}" class="btn btn-danger">Annuler</a>
+                        <a href="{{ route('admin.articles.index') }}" class="btn btn-danger">Annuler</a>
                     </div>
                 </form>
             </div>

--- a/resources/views/articles/index.blade.php
+++ b/resources/views/articles/index.blade.php
@@ -19,7 +19,7 @@
             <div class="card-header">
                 <div class="d-flex align-items-center">
                     <h4 class="card-title">Liste des Articles</h4>
-                    <a href="{{ route('articles.create') }}" class="btn btn-primary btn-round ms-auto">
+                    <a href="{{ route('admin.articles.create') }}" class="btn btn-primary btn-round ms-auto">
                         <i class="fa fa-plus"></i>
                         Ajouter un Article
                     </a>
@@ -46,13 +46,10 @@
                                 <td>{{ $article->quantite }}</td>
                                 <td>
                                     <div class="form-button-action">
-                                        <a href="{{ route('articles.show', $article->id) }}" data-bs-toggle="tooltip" title="Voir" class="btn btn-link btn-primary btn-lg">
-                                            <i class="fa fa-eye"></i>
-                                        </a>
-                                        <a href="{{ route('articles.edit', $article->id) }}" data-bs-toggle="tooltip" title="Modifier" class="btn btn-link btn-primary btn-lg">
+                                        <a href="{{ route('admin.articles.edit', $article->id) }}" data-bs-toggle="tooltip" title="Modifier" class="btn btn-link btn-primary btn-lg">
                                             <i class="fa fa-edit"></i>
                                         </a>
-                                        <form action="{{ route('articles.destroy', $article->id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer cet article ?');">
+                                        <form action="{{ route('admin.articles.destroy', $article->id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer cet article ?');">
                                             @csrf
                                             @method('DELETE')
                                             <button type="submit" data-bs-toggle="tooltip" title="Supprimer" class="btn btn-link btn-danger">


### PR DESCRIPTION
This commit resolves the 'Route [...] not defined' errors for admin article actions.

- Updated `resources/views/articles/index.blade.php` to use `admin.articles.create`, `admin.articles.edit`, and `admin.articles.destroy` for route generation. Also removed a link to the non-existent `admin.articles.show` route.
- Updated `resources/views/articles/create.blade.php` to use `admin.articles.index` for breadcrumbs/cancel links and `admin.articles.store` for the form action.
- Updated `resources/views/articles/edit.blade.php` to use `admin.articles.index` for breadcrumbs/cancel links and `admin.articles.update` for the form action. The home breadcrumb was also changed to point to `admin.articles.index`.

These changes ensure that all links and forms within the admin article management views correctly reference the named routes defined with the 'admin.' prefix.