### PR TITLE
fix: Resolve user photo errors and align storage path

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -47,8 +47,8 @@ class ProfileController extends Controller
             if ($user->photo) {
                 Storage::disk('public')->delete($user->photo);
             }
-            // Stocke la nouvelle photo dans 'public/images'.
-            $path = $request->file('photo')->store('images', 'public');
+            // Stocke la nouvelle photo dans 'public/avatars'.
+            $path = $request->file('photo')->store('avatars', 'public');
             $user->photo = $path; // Met à jour l'attribut photo de l'utilisateur.
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -71,9 +71,9 @@ class UserController extends Controller
 
         // Si une photo est téléversée, la sauvegarde.
         if ($request->hasFile('photo')) {
-            // Stocke dans 'storage/app/public/images' et récupère le chemin.
-            $path = $request->file('photo')->store('images', 'public');
-            $data['photo'] = $path; // Stocke le chemin relatif 'images/xxxxx.jpg'.
+            // Stocke dans 'storage/app/public/avatars' et récupère le chemin.
+            $path = $request->file('photo')->store('avatars', 'public');
+            $data['photo'] = $path; // Stocke le chemin relatif 'avatars/xxxxx.jpg'.
         }
 
         // Crée l'utilisateur.
@@ -162,7 +162,7 @@ class UserController extends Controller
                 Storage::disk('public')->delete($user->photo);
             }
             // Stocke la nouvelle photo.
-            $path = $request->file('photo')->store('images', 'public');
+            $path = $request->file('photo')->store('avatars', 'public');
             $data['photo'] = $path; // Ajoute le chemin de la nouvelle photo aux données à mettre à jour.
         }
 

--- a/resources/views/layouts/navhead.blade.php
+++ b/resources/views/layouts/navhead.blade.php
@@ -43,13 +43,14 @@
 
             @include('layouts.notification')
 
+            @auth
             <li class="nav-item topbar-user dropdown hidden-caret">
                 <a class="dropdown-toggle profile-pic" data-bs-toggle="dropdown" href="#" aria-expanded="false">
                     <div class="avatar-sm">
                         <img src="{{ Auth::user()->photo ? asset('storage/' . Auth::user()->photo) : asset('assets/img/kaiadmin/default-avatar.png') }}" alt="Image de Profil" class="avatar-img rounded-circle" />
                     </div>
                     <span class="profile-username">
-                        <span class="fw-bold">{{ Auth::user()->name ?? 'Utilisateur' }}</span>
+                        <span class="fw-bold">{{ Auth::user()->name }}</span>
                     </span>
                 </a>
                 <ul class="dropdown-menu dropdown-user animated fadeIn">
@@ -60,8 +61,8 @@
                                      <img src="{{ Auth::user()->photo ? asset('storage/' . Auth::user()->photo) : asset('assets/img/kaiadmin/default-avatar.png') }}" alt="Image de Profil" class="avatar-img rounded" />
                                 </div>
                                 <div class="u-text">
-                                    <h4>{{ Auth::user()->name ?? 'Utilisateur' }}</h4>
-                                    <p class="text-muted mb-1">{{ Auth::user()->email ?? '' }}</p>
+                                    <h4>{{ Auth::user()->name }}</h4>
+                                    <p class="text-muted mb-1">{{ Auth::user()->email }}</p>
                                     <a class="btn btn-xs btn-secondary btn-sm" href="{{ route('profile.edit') }}">Voir le Profil</a>
                                 </div>
                             </div>
@@ -85,6 +86,19 @@
                     </div>
                 </ul>
             </li>
+            @else
+            {{-- Liens Connexion/Inscription pour les utilisateurs non authentifiés --}}
+            <li class="nav-item dropdown hidden-caret">
+                <a class="nav-link" href="{{ route('custom.login') }}">
+                    <i class="fas fa-sign-in-alt me-2"></i> Connexion
+                </a>
+            </li>
+            <li class="nav-item dropdown hidden-caret">
+                <a class="nav-link" href="{{ route('custom.register') }}">
+                    <i class="fas fa-user-plus me-2"></i> Inscription
+                </a>
+            </li>
+            @endauth
         </ul>
     </div>
 </nav>


### PR DESCRIPTION
This commit addresses critical issues with user photo functionality and refactors the storage path for user avatars.

1.  **Fixed "Attempt to read property 'photo' on null" Error:**
    *   I diagnosed the error as occurring in `layouts/navhead.blade.php` due to unconditional access to `Auth::user()` properties.
    *   I wrapped user-specific sections in `navhead.blade.php` with `@auth` directives and added an `@else` block for login/register links for guest users. This ensures user data is only accessed when available.

2.  **Refactored User Photo Storage Path:**
    *   I changed the storage directory for user-uploaded photos from the generic `storage/app/public/images/` to the more specific `storage/app/public/avatars/`.
    *   I updated `UserController` (store and update methods) and `ProfileController` (update method) to use the new `avatars/` path when storing photos.
    *   The existing logic for deleting old photos remains effective as it uses the path stored in the database, correctly handling photos from either the old or new directory.
    *   Blade views will continue to display images correctly using `asset('storage/' . $user->photo)` as the stored path will now reflect `avatars/` for new uploads.

3.  **Previous Fixes Included in Scope (from prior work in this session):**
    *   I resolved a logout error caused by an incorrect form action in `navhead.blade.php`.
    *   I enhanced `navhead.blade.php` with e-commerce features: improved user dropdown, cart link with item count, wishlist link, and a basic search bar.

These changes ensure a more robust and correctly functioning user photo system, resolve a critical logout bug, and improve header navigation. The user photo storage is now more organized.