### PR TITLE
fix: Resolve photo display and email verification route errors

### DIFF
--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,10 +1,7 @@
 <section>
     {{-- Header removed as it's now in the parent card --}}
 
-    <form id="send-verification" method="post" action="{{ route('verification.send') }}">
-        @csrf
-    </form>
-
+    {{-- The main form for updating profile information --}}
     <form method="post" action="{{ route('profile.update') }}" class="mt-3" enctype="multipart/form-data">
         @csrf
         @method('patch')
@@ -24,23 +21,32 @@
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
 
-            @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
-                <div class="mt-2">
-                    <p class="text-sm text-muted">
-                        {{ __('Your email address is unverified.') }}
+            {{-- Start: Conditional Email Verification Section --}}
+            @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail)
+                {{-- Hidden form for re-sending verification email --}}
+                {{-- This form is only defined if the user model uses email verification --}}
+                <form id="send-verification" method="post" action="{{ route('verification.send') }}" class="d-none">
+                    @csrf
+                </form>
 
-                        <button form="send-verification" class="btn btn-link p-0 text-sm text-primary">
-                            {{ __('Click here to re-send the verification email.') }}
-                        </button>
-                    </p>
-
-                    @if (session('status') === 'verification-link-sent')
-                        <p class="mt-2 text-sm text-success">
-                            {{ __('A new verification link has been sent to your email address.') }}
+                @if (! $user->hasVerifiedEmail())
+                    <div class="mt-2">
+                        <p class="text-sm text-muted">
+                            {{ __('Your email address is unverified.') }}
+                            {{-- This button triggers the hidden form above --}}
+                            <button form="send-verification" class="btn btn-link p-0 text-sm text-primary">
+                                {{ __('Click here to re-send the verification email.') }}
+                            </button>
                         </p>
-                    @endif
-                </div>
+                        @if (session('status') === 'verification-link-sent')
+                            <p class="mt-2 text-sm text-success">
+                                {{ __('A new verification link has been sent to your email address.') }}
+                            </p>
+                        @endif
+                    </div>
+                @endif
             @endif
+            {{-- End: Conditional Email Verification Section --}}
         </div>
 
         <div class="form-group mt-3">


### PR DESCRIPTION
This commit addresses two key issues:
1.  **Resolves "Attempt to read property 'photo' on null" Error:**
    *   The error, often occurring on the profile page, was traced to `layouts/navhead.blade.php` where `Auth::user()` properties (like photo and name) were accessed without ensuring the user was authenticated.
    *   Fixed by wrapping all user-specific sections within `navhead.blade.php` with `@auth` directives. An `@else` block was added to display Login/Register links for guest users.

2.  **Resolves "Route [verification.send] not defined" Error:**
    *   This error occurred on the profile page because the `update-profile-information-form.blade.php` partial attempted to generate a URL for `route('verification.send')` even when email verification was not fully configured (i.e., User model not implementing `MustVerifyEmail` and routes not loaded).
    *   Fixed by making the entire email verification UI section (including the form that calls `route('verification.send')`) in `update-profile-information-form.blade.php` conditional on the User model implementing the `MustVerifyEmail` interface. Since it currently does not, this UI (and the problematic route call) will not be rendered.

Additionally, this commit includes the previously implemented refactoring of user photo storage:
*   User photo storage directory changed from `images/` to `avatars/` in `UserController` and `ProfileController` for better organization, aligning conceptually with product image storage in `articles/`.

These changes ensure a more stable user interface, prevent errors related to unauthenticated access and undefined routes, and organize user file storage more clearly.