### PR TITLE
fix: Resolve undefined route errors on profile page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\StatistiqueController;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\Auth\PasswordController; // Added import for PasswordController
 use Illuminate\Support\Facades\Route;
 
 
@@ -65,6 +66,7 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     Route::get('/profile/orders', [ProfileController::class, 'orderHistory'])->name('profile.orders');
+    Route::put('user/password', [PasswordController::class, 'update'])->name('password.update');
 });
 
 // require __DIR__.'/auth.php'; // Commented out to disable default Breeze/UI auth routes


### PR DESCRIPTION
This commit fixes two 'route not defined' errors encountered when accessing or interacting with your profile page:

1.  **Resolves "Route [verification.send] not defined":**
    *   The User model does not currently implement `MustVerifyEmail`.
    *   The `update-profile-information-form.blade.php` partial was attempting to render a form with `action="{{ route('verification.send') }}"` regardless.
    *   Fixed by making the entire email verification UI section (including the form calling `route('verification.send')`) conditional on the User model implementing the `MustVerifyEmail` interface. Since it currently does not, this UI and the problematic route call are no longer rendered.

2.  **Resolves "Route [password.update] not defined":**
    *   The `update-password-form.blade.php` partial uses `action="{{ route('password.update') }}"`.
    *   This route was defined in `routes/auth.php` (which is not loaded) but was missing from `routes/web.php`.
    *   The required `App\Http\Controllers\Auth\PasswordController.php` exists.
    *   Fixed by adding a specific route definition for `password.update` to `routes/web.php` under the `auth` middleware group, pointing to `PasswordController@update`.
        `Route::put('user/password', [PasswordController::class, 'update'])->name('password.update');`

Additionally, a general review of other routes used on the profile page (`profile.edit`, `profile.update`, `profile.destroy`, `profile.orders`, `dashboard`) confirmed they are correctly defined.

These changes ensure the profile page renders correctly without route definition errors for authenticated users.