### PR TITLE
feat: Implement role-based platform segregation

### DIFF
--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -22,208 +22,201 @@
             <h4 class="text-section">Menu Principal</h4>
           </li>
 
-            {{-- @if (auth()->user()->hasRole('compagnie')) --}}
-
-              {{-- @elseif (auth()->user()->hasRole('admin')) --}}
-                <li class="nav-item">
-                    <a data-bs-toggle="collapse" href="#demande">
-                        <i class="fas fa-plus"></i>
-                    <p>Catalogue & Article</p>
-                    <span class="caret"></span>
-                    </a>
-                    <div class="collapse" id="demande">
-                    <ul class="nav nav-collapse">
-                        <li>
-                            <a href="{{ route('admin.articles.create') }}">
-                                <i class="fas fa-cart-plus"></i>
-                                <p>Ajouter un article</p>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('admin.articles.index') }}">
-                                <i class="fas fa-edit"></i>
-                                <p>Gérer les articles</p>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('admin.categories.index') }}">
-                                <i class="fas fa-tags"></i> {{-- Changed icon --}}
-                                <p>Catégories</p>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('admin.emplacements.index') }}">
-                                <i class="fas fa-map-marker-alt"></i> {{-- Changed icon --}}
-                                <p>Emplacements</p>
-                            </a>
-                        </li>
-
-                    </ul>
-                    </div>
-                </li>
-
-                <li class="nav-item">
-                    <a data-bs-toggle="collapse" href="#fournisseur">
-                        <i class="fas fa-shipping-fast"></i>
-                    <p>Fournisseur</p>
-                    <span class="caret"></span>
-                    </a>
-                    <div class="collapse" id="fournisseur">
-                    <ul class="nav nav-collapse">
-                        <li>
-                            <a href="{{ route('admin.fournisseurs.create') }}">
-                                <i class="fas fa-user-plus"></i> {{-- Changed icon --}}
-                                <p>Ajouter un fournisseur</p>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('admin.fournisseurs.index') }}">
-                                <i class="fas fa-users-cog"></i> {{-- Changed icon --}}
-                                <p>Gérer les fournisseurs</p>
-                            </a>
-                        </li>
-
-                    </ul>
-                    </div>
-                </li>
-
-                <li class="nav-item">
-                    <a data-bs-toggle="collapse" href="#ecommerce">
-                        <i class="fas fa-store"></i> {{-- E-commerce Icon --}}
-                    <p>Gestion E-commerce</p>
-                    <span class="caret"></span>
-                    </a>
-                    <div class="collapse" id="ecommerce">
-                        <ul class="nav nav-collapse">
-                            <li>
-                                <a href="{{ route('admin.orders.index') }}">
-                                    <i class="fas fa-shopping-cart"></i> {{-- Orders Icon --}}
-                                    <p>Commandes</p>
-                                </a>
-                            </li>
-                            {{-- We can add a direct link to public product listing or other e-commerce specific links here --}}
-                        </ul>
-                    </div>
-                </li>
-
-                <li class="nav-item">
-                    <a data-bs-toggle="collapse" href="#facture">
-                        <i class="fas fa-money-check-alt"></i>
-                    <p>Facture</p>
-                    <span class="caret"></span>
-                    </a>
-                    <div class="collapse" id="facture">
-                    <ul class="nav nav-collapse">
-                        <li>
-                            <a href="{{ route('admin.factures.create') }}">
-                                <i class="fas fa-file-invoice-dollar"></i> {{-- Changed icon --}}
-                                <p>Créer une facture</p>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('admin.factures.index') }}">
-                                <i class="fas fa-folder-open"></i> {{-- Changed icon --}}
-                                <p>Gérer les factures</p>
-                            </a>
-                        </li>
-
-                    </ul>
-                    </div>
-                </li>
-
-
-            {{-- @endif --}}
-
-            {{-- @if (auth()->user()->hasRole('admin')) --}}
-              <li class="nav-item">
-                <a href="{{ route('statistiques.index') }}">
-                  <i class="fas fa-chart-line"></i>
-                    <p>Statistiques</p>
+            @hasrole('admin')
+            <li class="nav-item">
+                <a data-bs-toggle="collapse" href="#demande">
+                    <i class="fas fa-plus"></i>
+                <p>Catalogue & Article</p>
+                <span class="caret"></span>
                 </a>
-              </li>
+                <div class="collapse" id="demande">
+                <ul class="nav nav-collapse">
+                    <li>
+                        <a href="{{ route('admin.articles.create') }}">
+                            <i class="fas fa-cart-plus"></i>
+                            <p>Ajouter un article</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ route('admin.articles.index') }}">
+                            <i class="fas fa-edit"></i>
+                            <p>Gérer les articles</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ route('admin.categories.index') }}">
+                            <i class="fas fa-tags"></i> {{-- Changed icon --}}
+                            <p>Catégories</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ route('admin.emplacements.index') }}">
+                            <i class="fas fa-map-marker-alt"></i> {{-- Changed icon --}}
+                            <p>Emplacements</p>
+                        </a>
+                    </li>
 
-            {{-- @if (auth()->user()->hasRole('admin')) --}}
+                </ul>
+                </div>
+            </li>
+
+            <li class="nav-item">
+                <a data-bs-toggle="collapse" href="#fournisseur">
+                    <i class="fas fa-shipping-fast"></i>
+                <p>Fournisseur</p>
+                <span class="caret"></span>
+                </a>
+                <div class="collapse" id="fournisseur">
+                <ul class="nav nav-collapse">
+                    <li>
+                        <a href="{{ route('admin.fournisseurs.create') }}">
+                            <i class="fas fa-user-plus"></i> {{-- Changed icon --}}
+                            <p>Ajouter un fournisseur</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ route('admin.fournisseurs.index') }}">
+                            <i class="fas fa-users-cog"></i> {{-- Changed icon --}}
+                            <p>Gérer les fournisseurs</p>
+                        </a>
+                    </li>
+
+                </ul>
+                </div>
+            </li>
+
+            <li class="nav-item">
+                <a data-bs-toggle="collapse" href="#ecommerce">
+                    <i class="fas fa-store"></i> {{-- E-commerce Icon --}}
+                <p>Gestion E-commerce</p>
+                <span class="caret"></span>
+                </a>
+                <div class="collapse" id="ecommerce">
+                    <ul class="nav nav-collapse">
+                        <li>
+                            <a href="{{ route('admin.orders.index') }}">
+                                <i class="fas fa-shopping-cart"></i> {{-- Orders Icon --}}
+                                <p>Commandes</p>
+                            </a>
+                        </li>
+                        {{-- We can add a direct link to public product listing or other e-commerce specific links here --}}
+                    </ul>
+                </div>
+            </li>
+
+            <li class="nav-item">
+                <a data-bs-toggle="collapse" href="#facture">
+                    <i class="fas fa-money-check-alt"></i>
+                <p>Facture</p>
+                <span class="caret"></span>
+                </a>
+                <div class="collapse" id="facture">
+                <ul class="nav nav-collapse">
+                    <li>
+                        <a href="{{ route('admin.factures.create') }}">
+                            <i class="fas fa-file-invoice-dollar"></i> {{-- Changed icon --}}
+                            <p>Créer une facture</p>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="{{ route('admin.factures.index') }}">
+                            <i class="fas fa-folder-open"></i> {{-- Changed icon --}}
+                            <p>Gérer les factures</p>
+                        </a>
+                    </li>
+
+                </ul>
+                </div>
+            </li>
+
+            <li class="nav-item">
+              <a href="{{ route('admin.statistiques.index') }}"> {{-- Updated route name --}}
+                <i class="fas fa-chart-line"></i>
+                  <p>Statistiques</p>
+              </a>
+            </li>
+
             <li class="nav-section">
                 <span class="sidebar-mini-icon">
                   <i class="fa fa-ellipsis-h"></i>
                 </span>
                 <h4 class="text-section">Administration</h4>
             </li>
-              <li class="nav-item">
-                  <a data-bs-toggle="collapse" href="#administration-menu"> {{-- Changed ID for clarity --}}
-                      <i class="fas fa-cogs"></i> {{-- Changed icon --}}
-                  <p>Paramètres</p>
-                  <span class="caret"></span>
-                  </a>
-                  <div class="collapse" id="administration-menu">
-                    <ul class="nav nav-collapse">
-                        <li class="nav-item">
-                            <a data-bs-toggle="collapse" href="#users-submenu"> {{-- Changed ID --}}
-                                <i class="fas fa-users"></i>
-                                <p>Utilisateurs</p>
-                                <span class="caret"></span>
-                            </a>
-                            <div class="collapse" id="users-submenu">
-                                <ul class="nav nav-collapse">
-                                <li>
-                                    <a href="{{ route('admin.users.index') }}">
-                                        <p>Liste des Utilisateurs</p>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ route('admin.users.create') }}">
-                                        <p>Créer un Utilisateur</p>
-                                    </a>
-                                </li>
-                                </ul>
-                            </div>
-                        </li>
-                        <li class="nav-item">
-                            <a data-bs-toggle="collapse" href="#roles-submenu"> {{-- Changed ID --}}
-                                <i class="fas fa-user-shield"></i>
-                                <p>Rôles</p>
-                                <span class="caret"></span>
-                            </a>
-                            <div class="collapse" id="roles-submenu">
-                                <ul class="nav nav-collapse">
-                                <li>
-                                    <a href="{{ route('admin.roles.index') }}">
-                                        <p>Liste des Rôles</p>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ route('admin.roles.create') }}">
-                                        <p>Créer un Rôle</p>
-                                    </a>
-                                </li>
-                                </ul>
-                            </div>
-                        </li>
-                        <li class="nav-item">
-                            <a data-bs-toggle="collapse" href="#permissions-submenu"> {{-- Changed ID --}}
-                                <i class="fas fa-key"></i> {{-- Changed icon --}}
-                                <p>Permissions</p>
-                                <span class="caret"></span>
-                            </a>
-                            <div class="collapse" id="permissions-submenu">
-                                <ul class="nav nav-collapse">
-                                <li>
-                                    <a href="{{ route('admin.permissions.index') }}">
-                                        <p>Liste des Permissions</p>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ route('admin.permissions.create') }}">
-                                        <p>Créer une Permission</p>
+            <li class="nav-item">
+                <a data-bs-toggle="collapse" href="#administration-menu"> {{-- Changed ID for clarity --}}
+                    <i class="fas fa-cogs"></i> {{-- Changed icon --}}
+                <p>Paramètres</p>
+                <span class="caret"></span>
+                </a>
+                <div class="collapse" id="administration-menu">
+                  <ul class="nav nav-collapse">
+                      <li class="nav-item">
+                          <a data-bs-toggle="collapse" href="#users-submenu"> {{-- Changed ID --}}
+                              <i class="fas fa-users"></i>
+                              <p>Utilisateurs</p>
+                              <span class="caret"></span>
+                          </a>
+                          <div class="collapse" id="users-submenu">
+                              <ul class="nav nav-collapse">
+                              <li>
+                                  <a href="{{ route('admin.users.index') }}">
+                                      <p>Liste des Utilisateurs</p>
+                                  </a>
+                              </li>
+                              <li>
+                                  <a href="{{ route('admin.users.create') }}">
+                                      <p>Créer un Utilisateur</p>
                                   </a>
                               </li>
                               </ul>
                           </div>
                       </li>
-                  </ul>
-                  </div>
-              </li>
-            {{-- @endif --}}
+                      <li class="nav-item">
+                          <a data-bs-toggle="collapse" href="#roles-submenu"> {{-- Changed ID --}}
+                              <i class="fas fa-user-shield"></i>
+                              <p>Rôles</p>
+                              <span class="caret"></span>
+                          </a>
+                          <div class="collapse" id="roles-submenu">
+                              <ul class="nav nav-collapse">
+                              <li>
+                                  <a href="{{ route('admin.roles.index') }}">
+                                      <p>Liste des Rôles</p>
+                                  </a>
+                              </li>
+                              <li>
+                                  <a href="{{ route('admin.roles.create') }}">
+                                      <p>Créer un Rôle</p>
+                                  </a>
+                              </li>
+                              </ul>
+                          </div>
+                      </li>
+                      <li class="nav-item">
+                          <a data-bs-toggle="collapse" href="#permissions-submenu"> {{-- Changed ID --}}
+                              <i class="fas fa-key"></i> {{-- Changed icon --}}
+                              <p>Permissions</p>
+                              <span class="caret"></span>
+                          </a>
+                          <div class="collapse" id="permissions-submenu">
+                              <ul class="nav nav-collapse">
+                              <li>
+                                  <a href="{{ route('admin.permissions.index') }}">
+                                      <p>Liste des Permissions</p>
+                                  </a>
+                              </li>
+                              <li>
+                                  <a href="{{ route('admin.permissions.create') }}">
+                                      <p>Créer une Permission</p>
+                                </a>
+                            </li>
+                            </ul>
+                        </div>
+                    </li>
+                </ul>
+                </div>
+            </li>
+            @endhasrole
         </ul>
       </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,8 +47,7 @@ Route::get('/checkout', [CheckoutController::class, 'index'])->name('checkout.in
 Route::post('/checkout', [CheckoutController::class, 'process'])->name('checkout.process'); // Middleware removed for guest checkout
 
 // Admin Routes for Order Management
-// Temporarily removing 'admin' middleware for testing due to BindingResolutionException
-Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () {
+Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('/orders', [AdminOrderController::class, 'index'])->name('orders.index');
     Route::get('/orders/{order}', [AdminOrderController::class, 'show'])->name('orders.show');
     Route::patch('/orders/{order}/status', [AdminOrderController::class, 'updateStatus'])->name('orders.updateStatus');
@@ -58,6 +57,19 @@ Route::middleware(['auth'])->prefix('admin')->name('admin.')->group(function () 
     // Public show route is /products/{id}, admin can use edit or a dedicated admin show if created
     // If ArticleController@show is used by admin, it might need adjustment or be fine.
     // For now, let's assume `except(['show'])` is a safe bet to avoid conflict with public productShow
+
+    // Moved resource routes
+    Route::resource('users', UserController::class);
+    Route::resource('roles', RoleController::class);
+    Route::resource('permissions', PermissionController::class);
+    Route::resource('categories', CategorieController::class);
+    Route::resource('fournisseurs', FournisseurController::class);
+    Route::resource('emplacements', EmplacementController::class);
+    Route::resource('factures', FactureController::class); // This will also name factura.show, edit, update, destroy to admin.factures.*
+
+    // Moved individual routes
+    Route::get('/factures/{facture}/pdf', [FactureController::class, 'genererPdf'])->name('factures.pdf');
+    Route::get('/statistiques', [StatistiqueController::class, 'index'])->name('statistiques.index');
 });
 
 Route::get('/dashboard', function () {
@@ -95,21 +107,11 @@ Route::middleware('auth')->group(function () {
 // require __DIR__.'/auth.php'; // Commented out to disable default Breeze/UI auth routes
 
 
-
-//la gestion des utilisateurs
-Route::resource('users', UserController::class);
-Route::resource('roles', RoleController::class);
-Route::resource('permissions', PermissionController::class);
-Route::resource('categories', CategorieController::class);
-Route::resource('fournisseurs', FournisseurController::class);
-Route::resource('emplacements',EmplacementController::class);
-Route::resource('factures', FactureController::class);
-Route::resource('accueil', AccueilController::class); // This likely creates a GET '/' route already if 'index' is typical resource method
+// `accueil` resource route remains public as its index serves the homepage.
+// Other methods (create, edit, etc.) if they exist and are admin-only would need separate admin routes or controller logic.
+Route::resource('accueil', AccueilController::class);
 // Ensure the primary GET / route is explicitly named 'home' and points to AccueilController@index
 Route::get('/', [App\Http\Controllers\AccueilController::class, 'index'])->name('home');
-
-Route::get('/factures/{facture}/pdf', [FactureController::class, 'genererPdf'])->name('factures.pdf');
-Route::get('/statistiques', [StatistiqueController::class, 'index'])->name('statistiques.index');
 
 // Notification routes
 Route::get('/notifications', [NotificationController::class, 'index'])->name('notifications.index');


### PR DESCRIPTION
This commit introduces a fundamental separation between public/user areas and administrative sections of the application.

1.  **Admin Route Protection:**
    *   All routes intended for administrative use have been consolidated under the `/admin` URL prefix and given the `admin.` route name prefix.
    *   These routes are now protected by `['auth', 'role:admin']` middleware, ensuring only authenticated administrators can access them. This includes CRUD operations for Users, Roles, Permissions, Categories, Articles (admin parts), Fournisseurs, Emplacements, Factures, as well as admin order management and statistics.

2.  **Public Route Verification:**
    *   Publicly accessible routes (homepage, product browsing, cart, checkout, login/register, user dashboard, user profile) have been confirmed to remain outside this admin protection and function as intended for guests or general authenticated users.

3.  **Sidebar UI Adjustment:**
    *   The main sidebar navigation (`layouts/sidebar.blade.php`) has been updated to conditionally display admin-specific links only to users with the 'admin' role, using the `@hasrole('admin')` directive.

This segregation enhances security and usability by ensuring that administrative functionalities are appropriately restricted. Further work may be required to refine UI elements in other parts of the application based on roles if needed.