### PR TITLE
fix: Resolve 'Target class [role] does not exist' error

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
+            'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
+            'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
This commit addresses a critical error preventing Spatie's role-based access control from functioning correctly.

The root cause of the "Target class [role] does not exist." error was identified as missing Spatie middleware aliases in the application's middleware configuration (`bootstrap/app.php` for Laravel 11).

The fix involves:
1.  Adding the necessary middleware aliases to `bootstrap/app.php`:
    *   `'role' => \Spatie\Permission\Middleware\RoleMiddleware::class`
    *   `'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class`
    *   `'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class`

With these aliases registered, Laravel can now correctly map route middleware like `role:admin` to Spatie's `RoleMiddleware`. This resolves the target class error and ensures that role-based restrictions on routes and conditional UI elements (like `@hasrole` directives) function as intended, making access controls coherent.

Spatie's configuration file (`config/permission.php`) was confirmed to be correctly pointing to `Spatie\Permission\Models\Role` and `Spatie\Permission\Models\Permission`, and custom models `app/Models/Role.php` and `app/Models/Permission.php` were found to be unrelated to this specific Spatie issue.