### PR TITLE
feat: Restrict sidebar to admins and require auth for add-to-cart

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -32,7 +32,11 @@
 <body>
 	<div class="wrapper">
 		<!-- Sidebar -->
-		@include('layouts.sidebar')
+		@auth
+			@hasrole('admin')
+				@include('layouts.sidebar')
+			@endhasrole
+		@endauth
 		<!-- End Sidebar -->
 
 		<div class="main-panel">

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,7 +37,7 @@ Route::get('/products/{id}', [ArticleController::class, 'productShow'])->name('p
 
 // Cart Routes
 Route::get('/cart', [CartController::class, 'index'])->name('cart.index');
-Route::post('/cart/add/{article}', [CartController::class, 'add'])->name('cart.add');
+// Route::post('/cart/add/{article}', [CartController::class, 'add'])->name('cart.add'); // Moved to auth group
 Route::patch('/cart/update/{article}', [CartController::class, 'update'])->name('cart.update');
 Route::delete('/cart/remove/{article}', [CartController::class, 'remove'])->name('cart.remove');
 Route::delete('/cart/clear', [CartController::class, 'clear'])->name('cart.clear');
@@ -119,11 +119,13 @@ Route::post('/notifications/{id}/mark-as-read', [NotificationController::class, 
 Route::get('/notifications/{id}', [NotificationController::class, 'show'])->name('notifications.show');
 Route::post('/notifications/mark-all-as-read', [NotificationController::class, 'markAllAsRead'])->name('notifications.markAllAsRead');
 
-// Wishlist Routes
+// Wishlist Routes / Add to Cart (Authenticated)
 Route::middleware(['auth'])->group(function () {
     Route::get('/wishlist', [App\Http\Controllers\WishlistController::class, 'index'])->name('wishlist.index');
     Route::post('/wishlist/add/{article}', [App\Http\Controllers\WishlistController::class, 'add'])->name('wishlist.add');
     Route::delete('/wishlist/remove/{article}', [App\Http\Controllers\WishlistController::class, 'remove'])->name('wishlist.remove');
+
+    Route::post('/cart/add/{article}', [CartController::class, 'add'])->name('cart.add'); // Moved here
 });
 
 // Custom Authentication Routes for Guests


### PR DESCRIPTION
This commit implements two key changes based on your feedback:

1.  **Conditional Sidebar Visibility:**
    *   Modified `resources/views/layouts/app.blade.php` to ensure the main sidebar (`@include('layouts.sidebar')`) is only rendered if the authenticated user has the 'admin' role, using `@auth @hasrole('admin')`.
    *   This restricts sidebar access to administrators, hiding it for regular authenticated clients. The main content panel is expected to adjust its width based on the theme's CSS when the sidebar is not present.

2.  **Authentication for "Add to Cart":**
    *   Modified `routes/web.php` to move the route responsible for adding items to the cart (`Route::post('/cart/add/{article}', ...)->name('cart.add');`) into an `auth` middleware group.
    *   This ensures that you must be authenticated before you can add items to your shopping cart. Unauthenticated users attempting this action will be redirected to the login page.

These changes improve role-based UI consistency and control over e-commerce actions.